### PR TITLE
Add brute force guard auth plugin

### DIFF
--- a/auth/bruteforceguard/auth.php
+++ b/auth/bruteforceguard/auth.php
@@ -1,0 +1,65 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Authentication guard for tool_bruteforce.
+ *
+ * This plugin does not authenticate users. It only executes on the login page
+ * and blocks access when the tool_bruteforce API reports that the requesting
+ * IP or user is blocked.
+ *
+ * @package    auth_bruteforceguard
+ * @copyright  2024
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/authlib.php');
+
+/**
+ * Guard authentication plugin.
+ */
+class auth_plugin_bruteforceguard extends auth_plugin_base {
+    public function __construct() {
+        $this->authtype = 'bruteforceguard';
+        $this->config = get_config('auth_bruteforceguard');
+    }
+
+    /**
+     * Always fail so other plugins can authenticate.
+     *
+     * @param string $username
+     * @param string $password
+     * @return bool false to allow other plugins to handle login.
+     */
+    public function user_login($username, $password) {
+        return false;
+    }
+
+    /**
+     * Hook executed on the login page.
+     *
+     * Blocks the request early if the IP or user is blocked by tool_bruteforce.
+     */
+    public function loginpage_hook() {
+        $ip = getremoteaddr(null);
+        $userid = null;
+        if (\tool_bruteforce\api::is_blocked($userid, $ip)) {
+            throw new \moodle_exception('blocked', 'auth_bruteforceguard');
+        }
+    }
+}

--- a/auth/bruteforceguard/lang/en/auth_bruteforceguard.php
+++ b/auth/bruteforceguard/lang/en/auth_bruteforceguard.php
@@ -1,0 +1,26 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Language strings for auth_bruteforceguard.
+ *
+ * @package   auth_bruteforceguard
+ * @copyright 2024
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['pluginname'] = 'Brute force guard';
+$string['blocked'] = 'Unable to log in at this time.';

--- a/auth/bruteforceguard/version.php
+++ b/auth/bruteforceguard/version.php
@@ -1,0 +1,29 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Version details for auth_bruteforceguard.
+ *
+ * @package    auth_bruteforceguard
+ * @copyright  2024
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->component = 'auth_bruteforceguard';
+$plugin->version   = 2024040900;
+$plugin->requires  = 2022041900; // Moodle 4.0.


### PR DESCRIPTION
## Summary
- Add authentication plugin `auth_bruteforceguard` which checks tool_bruteforce API on the login page and blocks if IP is banned

## Testing
- `php admin/tool/phpunit/cli/init.php` *(fails: config.php missing)*
- `vendor/bin/phpunit admin/tool/bruteforce/tests` *(fails: config.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689528eaa21c832a9b494e4178e35bc8