### PR TITLE
feat: add token revocation and configurable block message

### DIFF
--- a/admin/tool/bruteforce/classes/api.php
+++ b/admin/tool/bruteforce/classes/api.php
@@ -157,6 +157,28 @@ class api {
     }
 
     /**
+     * Revoke a recently created web service token.
+     *
+     * @param int $tokenid Token id.
+     * @param int $userid User id owning the token.
+     * @param string $ip IP address used when requesting the token.
+     */
+    public static function revoke_token(int $tokenid, int $userid, string $ip): void {
+        global $DB;
+
+        $window = (int) get_config('tool_bruteforce', 'tokenrevokewindow');
+        if ($window <= 0) {
+            return;
+        }
+
+        $token = $DB->get_record('external_tokens', ['id' => $tokenid], 'id, timecreated');
+        if ($token && (time() - (int)$token->timecreated) <= $window) {
+            $DB->delete_records('external_tokens', ['id' => $tokenid]);
+            self::log('revoketoken', $ip, $userid, '', 'recenttoken', null);
+        }
+    }
+
+    /**
      * Write an audit log entry.
      *
      * @param string $eventtype

--- a/admin/tool/bruteforce/classes/observers.php
+++ b/admin/tool/bruteforce/classes/observers.php
@@ -25,7 +25,20 @@ class observers {
      */
     public static function user_loggedin(\core\event\user_loggedin $event): void {
         $ip = getremoteaddr(null);
-        $userid = $event->userid;
+       $userid = $event->userid;
         api::success($userid, $ip);
+    }
+
+    /**
+     * Revoke freshly created tokens if the requester is blocked.
+     *
+     * @param \core\event\webservice_token_created $event
+     */
+    public static function webservice_token_created(\core\event\webservice_token_created $event): void {
+        $ip = getremoteaddr(null);
+        $userid = $event->relateduserid;
+        if (api::is_blocked($userid, $ip)) {
+            api::revoke_token($event->objectid, $userid, $ip);
+        }
     }
 }

--- a/admin/tool/bruteforce/db/events.php
+++ b/admin/tool/bruteforce/db/events.php
@@ -12,4 +12,9 @@ $observers = [
         'callback'    => '\\tool_bruteforce\\observers::user_loggedin',
         'priority'    => 9999,
     ],
+    [
+        'eventname'   => '\\core\\event\\webservice_token_created',
+        'callback'    => '\\tool_bruteforce\\observers::webservice_token_created',
+        'priority'    => 9999,
+    ],
 ];

--- a/admin/tool/bruteforce/db/upgrade.php
+++ b/admin/tool/bruteforce/db/upgrade.php
@@ -120,5 +120,12 @@ function xmldb_tool_bruteforce_upgrade(int $oldversion): bool {
         upgrade_plugin_savepoint(true, 2024040300, 'tool', 'bruteforce');
     }
 
+    if ($oldversion < 2024040400) {
+        if (!get_config('tool_bruteforce', 'tokenrevokewindow')) {
+            set_config('tokenrevokewindow', 5, 'tool_bruteforce');
+        }
+        upgrade_plugin_savepoint(true, 2024040400, 'tool', 'bruteforce');
+    }
+
     return true;
 }

--- a/admin/tool/bruteforce/lang/en/tool_bruteforce.php
+++ b/admin/tool/bruteforce/lang/en/tool_bruteforce.php
@@ -22,5 +22,7 @@ $string['lists'] = 'Manage lists';
 $string['delete'] = 'Delete';
 $string['confirmdelete'] = 'Are you sure you want to delete this entry?';
 $string['blockedmessage'] = 'Unable to log in at this time.';
+$string['tokenrevokewindow'] = 'Token revocation window';
+$string['tokenrevokewindow_desc'] = 'Time after creation (in seconds) within which tokens are removed when the request is blocked.';
 $string['none'] = 'None';
 $string['bruteforce:manage'] = 'Manage bruteforce protection';

--- a/admin/tool/bruteforce/lang/es/tool_bruteforce.php
+++ b/admin/tool/bruteforce/lang/es/tool_bruteforce.php
@@ -22,5 +22,7 @@ $string['lists'] = 'Gestionar listas';
 $string['delete'] = 'Eliminar';
 $string['confirmdelete'] = '¿Estás seguro de que quieres eliminar esta entrada?';
 $string['blockedmessage'] = 'No es posible iniciar sesión en este momento.';
+$string['tokenrevokewindow'] = 'Ventana de revocación de token';
+$string['tokenrevokewindow_desc'] = 'Tiempo tras la creación (en segundos) dentro del cual los tokens se eliminan cuando la solicitud es bloqueada.';
 $string['none'] = 'Ninguno';
 $string['bruteforce:manage'] = 'Gestionar protección contra fuerza bruta';

--- a/admin/tool/bruteforce/settings.php
+++ b/admin/tool/bruteforce/settings.php
@@ -78,5 +78,21 @@ if ($hassiteconfig) {
         PARAM_INT
     ));
 
+    // Message displayed when access is blocked.
+    $settings->add(new admin_setting_configtext(
+        'tool_bruteforce/blockedmessage',
+        get_string('blockedmessage', 'tool_bruteforce'),
+        '',
+        get_string('blockedmessage', 'tool_bruteforce')
+    ));
+
+    // Time window for revoking freshly created tokens.
+    $settings->add(new admin_setting_configduration(
+        'tool_bruteforce/tokenrevokewindow',
+        get_string('tokenrevokewindow', 'tool_bruteforce'),
+        get_string('tokenrevokewindow_desc', 'tool_bruteforce'),
+        5
+    ));
+
     $ADMIN->add('security', $settings);
 }

--- a/admin/tool/bruteforce/tests/api_test.php
+++ b/admin/tool/bruteforce/tests/api_test.php
@@ -5,6 +5,7 @@ defined('MOODLE_INTERNAL') || die();
 
 use advanced_testcase;
 use tool_bruteforce\api;
+use context_system;
 
 /**
  * Unit tests for bruteforce API.
@@ -88,5 +89,40 @@ class api_test extends advanced_testcase {
         // Check if one day block was created
         $this->assertTrue($DB->record_exists('tool_bruteforce_oneday', ['ip' => '10.0.0.1']));
         $this->assertTrue(api::is_blocked(null, '10.0.0.1'));
+    }
+
+    public function test_token_revoked_when_blocked() {
+        global $DB;
+        $this->resetAfterTest();
+
+        // Prepare config.
+        set_config('tokenrevokewindow', 60, 'tool_bruteforce');
+
+        // Create user and block it.
+        $user = $this->getDataGenerator()->create_user();
+        $ip = '9.9.9.9';
+        api::block($user->id, $ip, 120);
+
+        // Simulate token creation from that IP.
+        $_SERVER['REMOTE_ADDR'] = $ip;
+        $token = (object) [
+            'token' => 'abc',
+            'userid' => $user->id,
+            'tokentype' => 0,
+            'timecreated' => time(),
+            'contextid' => \context_system::instance()->id,
+            'creatorid' => $user->id,
+        ];
+        $tokenid = $DB->insert_record('external_tokens', $token);
+
+        $event = \core\event\webservice_token_created::create([
+            'objectid' => $tokenid,
+            'relateduserid' => $user->id,
+            'other' => ['auto' => true],
+        ]);
+        $event->trigger();
+
+        $this->assertFalse($DB->record_exists('external_tokens', ['id' => $tokenid]));
+        $this->assertTrue($DB->record_exists('tool_bruteforce_audit', ['eventtype' => 'revoketoken', 'userid' => $user->id]));
     }
 }

--- a/admin/tool/bruteforce/version.php
+++ b/admin/tool/bruteforce/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024040300;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024040400;    // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2022041900;    // Requires Moodle 4.1.
 $plugin->component = 'tool_bruteforce';
 $plugin->maturity  = MATURITY_ALPHA;
-$plugin->release   = '0.3';
+$plugin->release   = '0.4';

--- a/auth/bruteforceguard/auth.php
+++ b/auth/bruteforceguard/auth.php
@@ -56,10 +56,25 @@ class auth_plugin_bruteforceguard extends auth_plugin_base {
      * Blocks the request early if the IP or user is blocked by tool_bruteforce.
      */
     public function loginpage_hook() {
+        global $DB;
+
+        // Resolve requesting IP and (if supplied) the user id of the username.
         $ip = getremoteaddr(null);
         $userid = null;
+        $username = optional_param('username', '', PARAM_RAW_TRIMMED);
+        if ($username !== '') {
+            $record = $DB->get_record('user', ['username' => $username, 'deleted' => 0], 'id', IGNORE_MISSING);
+            if ($record) {
+                $userid = (int)$record->id;
+            }
+        }
+
         if (\tool_bruteforce\api::is_blocked($userid, $ip)) {
-            throw new \moodle_exception('blocked', 'auth_bruteforceguard');
+            $msg = (string) get_config('tool_bruteforce', 'blockedmessage');
+            if ($msg === '') {
+                $msg = get_string('blockedmessage', 'tool_bruteforce');
+            }
+            throw new \moodle_exception('blocked', 'auth_bruteforceguard', '', $msg);
         }
     }
 }

--- a/auth/bruteforceguard/lang/en/auth_bruteforceguard.php
+++ b/auth/bruteforceguard/lang/en/auth_bruteforceguard.php
@@ -23,4 +23,5 @@
  */
 
 $string['pluginname'] = 'Brute force guard';
-$string['blocked'] = 'Unable to log in at this time.';
+// Displayed when a request is blocked; the actual text is provided via the tool_bruteforce setting.
+$string['blocked'] = '{$a}';

--- a/auth/bruteforceguard/version.php
+++ b/auth/bruteforceguard/version.php
@@ -25,5 +25,5 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'auth_bruteforceguard';
-$plugin->version   = 2024040900;
+$plugin->version   = 2024040901;
 $plugin->requires  = 2022041900; // Moodle 4.0.


### PR DESCRIPTION
## Summary
- Guard plugin now checks username and IP against tool_bruteforce and shows configurable neutral block message
- tool_bruteforce gains token revocation and settings for block message and revocation window
- Added event observer for webservice token creation and unit test for revocation

## Testing
- `php admin/tool/phpunit/cli/init.php` *(fails: Failed opening required '/workspace/moodle/lib/phpunit/../../config.php')*
- `vendor/bin/phpunit admin/tool/bruteforce/tests` *(fails: Failed opening required '/workspace/moodle/lib/phpunit/../../config.php')*

------
https://chatgpt.com/codex/tasks/task_e_68952dadcaac832abc2968c346ea0417