### PR TITLE
Add caching and attempt coalescence to bruteforce tool

### DIFF
--- a/admin/tool/bruteforce/classes/api.php
+++ b/admin/tool/bruteforce/classes/api.php
@@ -23,6 +23,17 @@ class api {
             return; // Never count.
         }
 
+        // Coalesce identical attempts within configured window to reduce DB load.
+        $coalesce = (int) get_config('tool_bruteforce', 'coalescewindow');
+        if ($coalesce > 0) {
+            $cache = \cache::make('tool_bruteforce', 'coalesce');
+            $key = sha1(($userid ?? 0) . '|' . $ip);
+            if ($cache->get($key)) {
+                return; // Skip counting the same attempt.
+            }
+            $cache->set($key, 1, $coalesce);
+        }
+
         $record = $DB->get_record('tool_bruteforce_attempts', ['userid' => $userid, 'ip' => $ip]);
         $now = time();
         if ($record) {
@@ -87,15 +98,28 @@ class api {
         if (self::is_blacklisted($ip)) {
             return true;
         }
-        $now = time();
-        if ($DB->record_exists_select('tool_bruteforce_oneday', 'ip = :ip AND unblocktime > :now', ['ip' => $ip, 'now' => $now])) {
-            return true;
+
+        $cache = \cache::make('tool_bruteforce', 'isblocked');
+        $key = ($userid ?? 0) . '|' . $ip;
+        $cached = $cache->get($key);
+        if ($cached !== false) {
+            return (bool) $cached;
         }
-        return $DB->record_exists_select('tool_bruteforce_blocks', 'ip = :ip AND (userid IS NULL OR userid = :userid) AND unblocktime > :now', [
-            'ip' => $ip,
-            'userid' => $userid,
-            'now' => $now,
-        ]);
+
+        $now = time();
+        $blocked = false;
+        if ($DB->record_exists_select('tool_bruteforce_oneday', 'ip = :ip AND unblocktime > :now', ['ip' => $ip, 'now' => $now])) {
+            $blocked = true;
+        } else {
+            $blocked = $DB->record_exists_select('tool_bruteforce_blocks', 'ip = :ip AND (userid IS NULL OR userid = :userid) AND unblocktime > :now', [
+                'ip' => $ip,
+                'userid' => $userid,
+                'now' => $now,
+            ]);
+        }
+
+        $cache->set($key, $blocked, 60);
+        return $blocked;
     }
 
     /**
@@ -112,6 +136,7 @@ class api {
             'timecreated' => time(),
         ];
         $DB->insert_record('tool_bruteforce_oneday', $record);
+        \cache::make('tool_bruteforce', 'isblocked')->purge();
         self::log('oneday', $ip, null, '', 'threshold', $duration);
     }
 
@@ -123,7 +148,13 @@ class api {
      */
     public static function is_whitelisted(string $ip): bool {
         global $CFG;
-        return !empty($CFG->allowedip) && address_in_subnet($ip, $CFG->allowedip);
+        $cache = \cache::make('tool_bruteforce', 'corelists');
+        $lists = $cache->get('lists');
+        if ($lists === false) {
+            $lists = ['allowedip' => $CFG->allowedip, 'blockedip' => $CFG->blockedip];
+            $cache->set('lists', $lists);
+        }
+        return !empty($lists['allowedip']) && address_in_subnet($ip, $lists['allowedip']);
     }
 
     /**
@@ -134,7 +165,13 @@ class api {
      */
     public static function is_blacklisted(string $ip): bool {
         global $CFG;
-        return !empty($CFG->blockedip) && address_in_subnet($ip, $CFG->blockedip);
+        $cache = \cache::make('tool_bruteforce', 'corelists');
+        $lists = $cache->get('lists');
+        if ($lists === false) {
+            $lists = ['allowedip' => $CFG->allowedip, 'blockedip' => $CFG->blockedip];
+            $cache->set('lists', $lists);
+        }
+        return !empty($lists['blockedip']) && address_in_subnet($ip, $lists['blockedip']);
     }
 
     /**
@@ -153,6 +190,7 @@ class api {
             'timecreated' => time(),
         ];
         $DB->insert_record('tool_bruteforce_blocks', $record);
+        \cache::make('tool_bruteforce', 'isblocked')->purge();
         self::log('block', $ip, $userid, '', 'threshold', $duration);
     }
 

--- a/admin/tool/bruteforce/db/caches.php
+++ b/admin/tool/bruteforce/db/caches.php
@@ -1,0 +1,21 @@
+<?php
+// Cache definitions for tool_bruteforce.
+
+defined('MOODLE_INTERNAL') || die();
+
+$definitions = [
+    // Cached copy of core allowedip/blockedip lists.
+    'corelists' => [
+        'mode' => cache_store::MODE_REQUEST,
+        'ttl' => 300,
+    ],
+    // Result of is_blocked(userid, ip).
+    'isblocked' => [
+        'mode' => cache_store::MODE_REQUEST,
+        'ttl' => 60,
+    ],
+    // Markers for coalescing identical attempts.
+    'coalesce' => [
+        'mode' => cache_store::MODE_REQUEST,
+    ],
+];

--- a/admin/tool/bruteforce/db/upgrade.php
+++ b/admin/tool/bruteforce/db/upgrade.php
@@ -127,5 +127,12 @@ function xmldb_tool_bruteforce_upgrade(int $oldversion): bool {
         upgrade_plugin_savepoint(true, 2024040400, 'tool', 'bruteforce');
     }
 
+    if ($oldversion < 2024040500) {
+        if (!get_config('tool_bruteforce', 'coalescewindow')) {
+            set_config('coalescewindow', 0, 'tool_bruteforce');
+        }
+        upgrade_plugin_savepoint(true, 2024040500, 'tool', 'bruteforce');
+    }
+
     return true;
 }

--- a/admin/tool/bruteforce/lang/en/tool_bruteforce.php
+++ b/admin/tool/bruteforce/lang/en/tool_bruteforce.php
@@ -24,5 +24,7 @@ $string['confirmdelete'] = 'Are you sure you want to delete this entry?';
 $string['blockedmessage'] = 'Unable to log in at this time.';
 $string['tokenrevokewindow'] = 'Token revocation window';
 $string['tokenrevokewindow_desc'] = 'Time after creation (in seconds) within which tokens are removed when the request is blocked.';
+$string['coalescewindow'] = 'Coalesce window';
+$string['coalescewindow_desc'] = 'Identical attempts from the same user and IP within this period (in seconds) are ignored.';
 $string['none'] = 'None';
 $string['bruteforce:manage'] = 'Manage bruteforce protection';

--- a/admin/tool/bruteforce/settings.php
+++ b/admin/tool/bruteforce/settings.php
@@ -94,5 +94,13 @@ if ($hassiteconfig) {
         5
     ));
 
+    // Coalesce window.
+    $settings->add(new admin_setting_configduration(
+        'tool_bruteforce/coalescewindow',
+        get_string('coalescewindow', 'tool_bruteforce'),
+        get_string('coalescewindow_desc', 'tool_bruteforce'),
+        0
+    ));
+
     $ADMIN->add('security', $settings);
 }

--- a/admin/tool/bruteforce/tests/api_test.php
+++ b/admin/tool/bruteforce/tests/api_test.php
@@ -125,4 +125,21 @@ class api_test extends advanced_testcase {
         $this->assertFalse($DB->record_exists('external_tokens', ['id' => $tokenid]));
         $this->assertTrue($DB->record_exists('tool_bruteforce_audit', ['eventtype' => 'revoketoken', 'userid' => $user->id]));
     }
+
+    public function test_coalesce_identical_attempts() {
+        global $DB;
+        $this->resetAfterTest();
+
+        set_config('thresholdsoft', 2, 'tool_bruteforce');
+        set_config('durationsoft', 60, 'tool_bruteforce');
+        set_config('window', 300, 'tool_bruteforce');
+        set_config('coalescewindow', 60, 'tool_bruteforce');
+
+        api::failed(null, '1.2.3.4');
+        api::failed(null, '1.2.3.4');
+
+        $record = $DB->get_record('tool_bruteforce_attempts', ['userid' => null, 'ip' => '1.2.3.4']);
+        $this->assertEquals(1, $record->count);
+        $this->assertFalse(api::is_blocked(null, '1.2.3.4'));
+    }
 }

--- a/admin/tool/bruteforce/version.php
+++ b/admin/tool/bruteforce/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024040400;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024040500;    // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2022041900;    // Requires Moodle 4.1.
 $plugin->component = 'tool_bruteforce';
 $plugin->maturity  = MATURITY_ALPHA;


### PR DESCRIPTION
## Summary
- Add MUC caches for IP lists, block results, and coalesced attempts
- Ignore duplicate login attempts within a configurable window
- Expose coalesce window admin setting and tests

## Testing
- `php admin/tool/phpunit/cli/init.php` *(fails: Failed opening required '/workspace/moodle/lib/phpunit/../../config.php')*
- `vendor/bin/phpunit admin/tool/bruteforce/tests` *(fails: Failed opening required '/workspace/moodle/lib/phpunit/../../config.php')*


------
https://chatgpt.com/codex/tasks/task_e_689530a54a2c832a938b3c1419556094