### PR TITLE
feat(tool_bruteforce): add history and user list management

### DIFF
--- a/admin/tool/bruteforce/classes/api.php
+++ b/admin/tool/bruteforce/classes/api.php
@@ -200,6 +200,38 @@ class api {
         return $lists;
     }
 
+    /**
+     * Add a username to a list.
+     *
+     * @param string $list whitelist or blacklist
+     * @param string $username username to add
+     * @param string $comment optional comment
+     */
+    public static function add_user_to_list(string $list, string $username, string $comment = ''): void {
+        global $DB;
+        $table = $list === 'blacklist' ? 'tool_bruteforce_ublacklist' : 'tool_bruteforce_uwhitelist';
+        $record = (object) [
+            'username' => core_text::strtolower($username),
+            'comment' => $comment ?: null,
+            'timecreated' => time(),
+        ];
+        $DB->insert_record($table, $record);
+        \cache::make('tool_bruteforce', 'userlists')->purge();
+    }
+
+    /**
+     * Remove a username entry from a list.
+     *
+     * @param string $list whitelist or blacklist
+     * @param int $id record id to remove
+     */
+    public static function remove_user_from_list(string $list, int $id): void {
+        global $DB;
+        $table = $list === 'blacklist' ? 'tool_bruteforce_ublacklist' : 'tool_bruteforce_uwhitelist';
+        $DB->delete_records($table, ['id' => $id]);
+        \cache::make('tool_bruteforce', 'userlists')->purge();
+    }
+
     /** Block an IP for one day. */
     protected static function block_ip_for_oneday(string $ip): void {
         global $DB;

--- a/admin/tool/bruteforce/classes/form/userlist_form.php
+++ b/admin/tool/bruteforce/classes/form/userlist_form.php
@@ -1,0 +1,51 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_bruteforce\form;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/formslib.php');
+
+/**
+ * Form to add usernames to white or black lists.
+ *
+ * @package    tool_bruteforce
+ */
+class userlist_form extends \moodleform {
+    /** @var string list type. */
+    protected string $list;
+
+    /**
+     * Define fields.
+     */
+    public function definition() {
+        $mform = $this->_form;
+        $this->list = $this->_customdata['list'];
+
+        $mform->addElement('text', 'username', get_string('username'));
+        $mform->setType('username', PARAM_USERNAME);
+        $mform->addRule('username', null, 'required', null, 'client');
+
+        $mform->addElement('text', 'comment', get_string('comment', 'tool_bruteforce'));
+        $mform->setType('comment', PARAM_TEXT);
+
+        $mform->addElement('hidden', 'list', $this->list);
+        $mform->setType('list', PARAM_ALPHA);
+
+        $this->add_action_buttons(false, get_string('add', 'tool_bruteforce'));
+    }
+}

--- a/admin/tool/bruteforce/lang/en/tool_bruteforce.php
+++ b/admin/tool/bruteforce/lang/en/tool_bruteforce.php
@@ -53,6 +53,7 @@ $string['confirmbulkunlock'] = 'Are you sure you want to unblock the selected en
 $string['filters'] = 'Filters';
 $string['resetfilters'] = 'Reset filters';
 $string['searchplaceholder'] = 'Search...';
+$string['exportcsv'] = 'Export CSV';
 $string['privacy:metadata:userid'] = 'User ID';
 $string['privacy:metadata:username'] = 'Username';
 $string['privacy:metadata:ip'] = 'IP address';

--- a/admin/tool/bruteforce/lang/es/tool_bruteforce.php
+++ b/admin/tool/bruteforce/lang/es/tool_bruteforce.php
@@ -58,6 +58,7 @@ $string['confirmbulkunlock'] = '¿Seguro que deseas desbloquear las entradas sel
 $string['filters'] = 'Filtros';
 $string['resetfilters'] = 'Restablecer filtros';
 $string['searchplaceholder'] = 'Buscar...';
+$string['exportcsv'] = 'Exportar CSV';
 $string['privacy:metadata:userid'] = 'ID de usuario';
 $string['privacy:metadata:username'] = 'Nombre de usuario';
 $string['privacy:metadata:ip'] = 'Dirección IP';

--- a/admin/tool/bruteforce/manage.php
+++ b/admin/tool/bruteforce/manage.php
@@ -155,6 +155,142 @@ switch ($section) {
         }
         break;
 
+    case 'history':
+        require_capability('tool/bruteforce:view', $context);
+
+        $filterip = optional_param('filterip', '', PARAM_RAW_TRIMMED);
+        $filteruser = optional_param('filteruser', '', PARAM_RAW_TRIMMED);
+        $filterevent = optional_param('filterevent', '', PARAM_ALPHA);
+        $download = optional_param('download', '', PARAM_ALPHA);
+
+        $params = [];
+        $where = '1=1';
+        if ($filterip !== '') {
+            $where .= ' AND ip LIKE :ip';
+            $params['ip'] = $filterip . '%';
+        }
+        if ($filteruser !== '') {
+            $where .= ' AND username LIKE :uname';
+            $params['uname'] = core_text::strtolower($filteruser) . '%';
+        }
+        if ($filterevent !== '') {
+            $where .= ' AND eventtype = :ev';
+            $params['ev'] = $filterevent;
+        }
+
+        $records = $DB->get_records_sql("SELECT * FROM {tool_bruteforce_audit} WHERE $where ORDER BY timecreated DESC", $params);
+
+        if ($download === 'csv') {
+            require_once($CFG->libdir . '/csvlib.class.php');
+            $export = new csv_export_writer();
+            $export->set_filename('bruteforce_history');
+            $export->add_data([get_string('event', 'tool_bruteforce'), get_string('ip', 'tool_bruteforce'),
+                get_string('username'), get_string('reason', 'tool_bruteforce'), get_string('duration', 'tool_bruteforce'),
+                get_string('created', 'tool_bruteforce')]);
+            foreach ($records as $r) {
+                $export->add_data([$r->eventtype, $r->ip, $r->username, $r->reason, $r->duration,
+                    userdate($r->timecreated)]);
+            }
+            $export->download_file();
+            exit;
+        }
+
+        echo html_writer::start_tag('form', ['method' => 'get', 'class' => 'mform']);
+        echo html_writer::start_div('filters');
+        echo html_writer::empty_tag('input', ['type' => 'hidden', 'name' => 'section', 'value' => 'history']);
+        echo html_writer::empty_tag('input', ['type' => 'text', 'name' => 'filterip', 'value' => s($filterip),
+            'placeholder' => get_string('ip', 'tool_bruteforce')]);
+        echo html_writer::empty_tag('input', ['type' => 'text', 'name' => 'filteruser', 'value' => s($filteruser),
+            'placeholder' => get_string('user')]);
+        echo html_writer::select(['' => get_string('event', 'tool_bruteforce'), 'failed' => 'failed',
+            'loggedin' => 'loggedin', 'block' => 'block', 'oneday' => 'oneday', 'revoketoken' => 'revoketoken'],
+            'filterevent', $filterevent, false);
+        echo html_writer::empty_tag('input', ['type' => 'submit', 'value' => get_string('apply', 'tool_bruteforce')]);
+        echo html_writer::link(new moodle_url($baseurl, ['section' => 'history']),
+            get_string('resetfilters', 'tool_bruteforce'));
+        echo html_writer::link(new moodle_url($baseurl, ['section' => 'history', 'download' => 'csv',
+            'filterip' => $filterip, 'filteruser' => $filteruser, 'filterevent' => $filterevent]),
+            get_string('exportcsv', 'tool_bruteforce'), ['class' => 'ml-2']);
+        echo html_writer::end_div();
+        echo html_writer::end_tag('form');
+
+        $table = new html_table();
+        $table->head = [
+            get_string('event', 'tool_bruteforce'),
+            get_string('ip', 'tool_bruteforce'),
+            get_string('username'),
+            get_string('reason', 'tool_bruteforce'),
+            get_string('duration', 'tool_bruteforce'),
+            get_string('created', 'tool_bruteforce'),
+        ];
+
+        foreach ($records as $r) {
+            $table->data[] = [s($r->eventtype), s($r->ip), s($r->username), s($r->reason),
+                $r->duration ? format_time($r->duration) : '', userdate($r->timecreated)];
+        }
+
+        if (!empty($table->data)) {
+            echo html_writer::table($table);
+        } else {
+            echo $OUTPUT->notification(get_string('none', 'tool_bruteforce'), 'notifymessage');
+        }
+        break;
+
+    case 'lists':
+        require_capability('tool/bruteforce:manage', $context);
+        require_once($CFG->dirroot . '/admin/tool/bruteforce/classes/form/userlist_form.php');
+
+        $delw = optional_param('delw', 0, PARAM_INT);
+        $delb = optional_param('delb', 0, PARAM_INT);
+        if ($delw && confirm_sesskey()) {
+            \tool_bruteforce\api::remove_user_from_list('whitelist', $delw);
+            redirect(new moodle_url($baseurl, ['section' => 'lists']));
+        }
+        if ($delb && confirm_sesskey()) {
+            \tool_bruteforce\api::remove_user_from_list('blacklist', $delb);
+            redirect(new moodle_url($baseurl, ['section' => 'lists']));
+        }
+
+        $whitelistform = new \tool_bruteforce\form\userlist_form(new moodle_url($baseurl,
+            ['section' => 'lists']), ['list' => 'whitelist']);
+        if ($data = $whitelistform->get_data()) {
+            \tool_bruteforce\api::add_user_to_list('whitelist', $data->username, $data->comment);
+            redirect(new moodle_url($baseurl, ['section' => 'lists']));
+        }
+        $blacklistform = new \tool_bruteforce\form\userlist_form(new moodle_url($baseurl,
+            ['section' => 'lists']), ['list' => 'blacklist']);
+        if ($data = $blacklistform->get_data()) {
+            \tool_bruteforce\api::add_user_to_list('blacklist', $data->username, $data->comment);
+            redirect(new moodle_url($baseurl, ['section' => 'lists']));
+        }
+
+        echo html_writer::tag('h3', get_string('whitelist', 'tool_bruteforce'));
+        $whitelistform->display();
+        $records = $DB->get_records('tool_bruteforce_uwhitelist', null, 'timecreated DESC');
+        $table = new html_table();
+        $table->head = [get_string('username'), get_string('comment', 'tool_bruteforce'),
+            get_string('created', 'tool_bruteforce'), get_string('actions')];
+        foreach ($records as $r) {
+            $del = new moodle_url($baseurl, ['section' => 'lists', 'delw' => $r->id, 'sesskey' => sesskey()]);
+            $table->data[] = [s($r->username), s($r->comment), userdate($r->timecreated),
+                html_writer::link($del, get_string('delete'))];
+        }
+        echo html_writer::table($table);
+
+        echo html_writer::tag('h3', get_string('blacklist', 'tool_bruteforce'));
+        $blacklistform->display();
+        $records = $DB->get_records('tool_bruteforce_ublacklist', null, 'timecreated DESC');
+        $table = new html_table();
+        $table->head = [get_string('username'), get_string('comment', 'tool_bruteforce'),
+            get_string('created', 'tool_bruteforce'), get_string('actions')];
+        foreach ($records as $r) {
+            $del = new moodle_url($baseurl, ['section' => 'lists', 'delb' => $r->id, 'sesskey' => sesskey()]);
+            $table->data[] = [s($r->username), s($r->comment), userdate($r->timecreated),
+                html_writer::link($del, get_string('delete'))];
+        }
+        echo html_writer::table($table);
+        break;
+
     case 'dashboard':
     default:
         require_capability('tool/bruteforce:view', $context);


### PR DESCRIPTION
## Summary
- add history tab with filters and CSV export
- manage whitelist/blacklist from unified page
- expose API helpers for user list CRUD

## Testing
- `vendor/bin/phpunit admin/tool/bruteforce/tests/api_test.php` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895f5116db8832a9e08337810eebe27