### PR TITLE
tool_bruteforce: add user list privacy and upgrade rename

### DIFF
--- a/admin/tool/bruteforce/README_QA.md
+++ b/admin/tool/bruteforce/README_QA.md
@@ -1,0 +1,14 @@
+# QA checklist for tool_bruteforce
+
+## Checklist
+- Single navigation node under *Site administration → Security* pointing to `manage.php`.
+- Tabs render Dashboard, Blocks, History, Lists and Settings (linking to `/admin/settings.php?section=tool_bruteforce`).
+- Blocks: add, filter, extend and bulk unblock/delete; cache `isblocked` purged after changes.
+- History: filters and CSV export respect applied filters.
+- Lists: CRUD for whitelist/blacklist with duplicate prevention and cache purge.
+- Observers: failed logins accumulate and successful logins reset counters; tokens revoked when blocked.
+
+## Backout plan
+- Rename tables back to `tool_bruteforce_userwhitelist` and `tool_bruteforce_userblacklist` if needed.
+- Remove test data from user lists and blocks tables.
+- Disable rescue mode and purge caches: `php admin/cli/purge_caches.php`.

--- a/admin/tool/bruteforce/classes/privacy/provider.php
+++ b/admin/tool/bruteforce/classes/privacy/provider.php
@@ -15,6 +15,8 @@ class provider implements \core_privacy\local\metadata\provider, \core_privacy\l
         $items->add_database_table('tool_bruteforce_blocks', ['userid' => 'privacy:metadata:userid', 'username' => 'privacy:metadata:username', 'ip' => 'privacy:metadata:ip'], 'privacy:metadata:blocks');
         $items->add_database_table('tool_bruteforce_oneday', ['ip' => 'privacy:metadata:ip'], 'privacy:metadata:oneday');
         $items->add_database_table('tool_bruteforce_audit', ['userid' => 'privacy:metadata:userid', 'username' => 'privacy:metadata:username', 'ip' => 'privacy:metadata:ip'], 'privacy:metadata:audit');
+        $items->add_database_table('tool_bruteforce_uwhitelist', ['username' => 'privacy:metadata:username', 'comment' => 'privacy:metadata:comment'], 'privacy:metadata:userlist');
+        $items->add_database_table('tool_bruteforce_ublacklist', ['username' => 'privacy:metadata:username', 'comment' => 'privacy:metadata:comment'], 'privacy:metadata:userlist');
         return $items;
     }
 
@@ -30,9 +32,18 @@ class provider implements \core_privacy\local\metadata\provider, \core_privacy\l
 
     protected static function record_exists(int $userid): bool {
         global $DB;
-        return $DB->record_exists('tool_bruteforce_attempts', ['userid'=>$userid]) ||
-               $DB->record_exists('tool_bruteforce_blocks', ['userid'=>$userid]) ||
-               $DB->record_exists('tool_bruteforce_audit', ['userid'=>$userid]);
+        $exists = $DB->record_exists('tool_bruteforce_attempts', ['userid' => $userid]) ||
+                  $DB->record_exists('tool_bruteforce_blocks', ['userid' => $userid]) ||
+                  $DB->record_exists('tool_bruteforce_audit', ['userid' => $userid]);
+        if (!$exists) {
+            $username = $DB->get_field('user', 'username', ['id' => $userid], IGNORE_MISSING);
+            if ($username) {
+                $username = \core_text::strtolower($username);
+                $exists = $DB->record_exists('tool_bruteforce_uwhitelist', ['username' => $username]) ||
+                          $DB->record_exists('tool_bruteforce_ublacklist', ['username' => $username]);
+            }
+        }
+        return $exists;
     }
 
     public static function export_user_data(approved_contextlist $contextlist) {
@@ -43,9 +54,15 @@ class provider implements \core_privacy\local\metadata\provider, \core_privacy\l
         $userid = $contextlist->get_user()->id;
         $context = context_system::instance();
         $data = new \stdClass();
-        $data->attempts = $DB->get_records('tool_bruteforce_attempts', ['userid'=>$userid]);
-        $data->blocks = $DB->get_records('tool_bruteforce_blocks', ['userid'=>$userid]);
-        $data->audit = $DB->get_records('tool_bruteforce_audit', ['userid'=>$userid]);
+        $data->attempts = $DB->get_records('tool_bruteforce_attempts', ['userid' => $userid]);
+        $data->blocks = $DB->get_records('tool_bruteforce_blocks', ['userid' => $userid]);
+        $data->audit = $DB->get_records('tool_bruteforce_audit', ['userid' => $userid]);
+        $username = $DB->get_field('user', 'username', ['id' => $userid], IGNORE_MISSING);
+        if ($username) {
+            $username = \core_text::strtolower($username);
+            $data->userwhitelist = $DB->get_records('tool_bruteforce_uwhitelist', ['username' => $username]);
+            $data->userblacklist = $DB->get_records('tool_bruteforce_ublacklist', ['username' => $username]);
+        }
         writer::with_context($context)->export_data([], $data);
     }
 
@@ -55,6 +72,8 @@ class provider implements \core_privacy\local\metadata\provider, \core_privacy\l
         $DB->delete_records('tool_bruteforce_blocks');
         $DB->delete_records('tool_bruteforce_oneday');
         $DB->delete_records('tool_bruteforce_audit');
+        $DB->delete_records('tool_bruteforce_uwhitelist');
+        $DB->delete_records('tool_bruteforce_ublacklist');
     }
 
     public static function delete_data_for_user(approved_contextlist $contextlist) {
@@ -63,8 +82,14 @@ class provider implements \core_privacy\local\metadata\provider, \core_privacy\l
             return;
         }
         $userid = $contextlist->get_user()->id;
-        $DB->delete_records('tool_bruteforce_attempts', ['userid'=>$userid]);
-        $DB->delete_records('tool_bruteforce_blocks', ['userid'=>$userid]);
-        $DB->delete_records('tool_bruteforce_audit', ['userid'=>$userid]);
+        $DB->delete_records('tool_bruteforce_attempts', ['userid' => $userid]);
+        $DB->delete_records('tool_bruteforce_blocks', ['userid' => $userid]);
+        $DB->delete_records('tool_bruteforce_audit', ['userid' => $userid]);
+        $username = $DB->get_field('user', 'username', ['id' => $userid], IGNORE_MISSING);
+        if ($username) {
+            $username = \core_text::strtolower($username);
+            $DB->delete_records('tool_bruteforce_uwhitelist', ['username' => $username]);
+            $DB->delete_records('tool_bruteforce_ublacklist', ['username' => $username]);
+        }
     }
 }

--- a/admin/tool/bruteforce/db/upgrade.php
+++ b/admin/tool/bruteforce/db/upgrade.php
@@ -289,5 +289,18 @@ function xmldb_tool_bruteforce_upgrade(int $oldversion): bool {
         upgrade_plugin_savepoint(true, 2024040601, 'tool', 'bruteforce');
     }
 
+    if ($oldversion < 2024040602) {
+        // Rename user list tables to shorter names to satisfy cross-DB identifier limits.
+        $table = new xmldb_table('tool_bruteforce_userwhitelist');
+        if ($dbman->table_exists($table) && !$dbman->table_exists('tool_bruteforce_uwhitelist')) {
+            $dbman->rename_table($table, 'tool_bruteforce_uwhitelist');
+        }
+        $table = new xmldb_table('tool_bruteforce_userblacklist');
+        if ($dbman->table_exists($table) && !$dbman->table_exists('tool_bruteforce_ublacklist')) {
+            $dbman->rename_table($table, 'tool_bruteforce_ublacklist');
+        }
+        upgrade_plugin_savepoint(true, 2024040602, 'tool', 'bruteforce');
+    }
+
     return true;
 }

--- a/admin/tool/bruteforce/lang/en/tool_bruteforce.php
+++ b/admin/tool/bruteforce/lang/en/tool_bruteforce.php
@@ -61,3 +61,5 @@ $string['privacy:metadata:attempts'] = 'Failed login attempts.';
 $string['privacy:metadata:blocks'] = 'Active blocks.';
 $string['privacy:metadata:oneday'] = 'One-day blocks.';
 $string['privacy:metadata:audit'] = 'Audit log entries.';
+$string['privacy:metadata:userlist'] = 'User allow/deny lists.';
+$string['privacy:metadata:comment'] = 'Comment for the entry.';

--- a/admin/tool/bruteforce/lang/es/tool_bruteforce.php
+++ b/admin/tool/bruteforce/lang/es/tool_bruteforce.php
@@ -66,4 +66,6 @@ $string['privacy:metadata:attempts'] = 'Intentos de inicio de sesión fallidos.'
 $string['privacy:metadata:blocks'] = 'Bloqueos activos.';
 $string['privacy:metadata:oneday'] = 'Bloqueos de un día.';
 $string['privacy:metadata:audit'] = 'Entradas de auditoría.';
+$string['privacy:metadata:userlist'] = 'Listas de usuarios permitidos/prohibidos.';
+$string['privacy:metadata:comment'] = 'Comentario de la entrada.';
 

--- a/admin/tool/bruteforce/version.php
+++ b/admin/tool/bruteforce/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024040601;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024040602;    // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2022041900;    // Requires Moodle 4.1.
 $plugin->component = 'tool_bruteforce';
 $plugin->maturity  = MATURITY_ALPHA;


### PR DESCRIPTION
## Summary
- include whitelist/blacklist tables in privacy API
- rename legacy user list tables during upgrade
- add QA checklist

## Testing
- `phpunit admin/tool/bruteforce/tests/api_test.php` *(fails: Failed opening required '/workspace/moodle/lib/phpunit/../../config.php')*


------
https://chatgpt.com/codex/tasks/task_e_6895f9fc2804832a9d870ea4328f8c39